### PR TITLE
Attach power-up trigger to orb

### DIFF
--- a/scripts/powerup.sqf
+++ b/scripts/powerup.sqf
@@ -1,14 +1,18 @@
-for "_i" from 1 to 30 do {
-sleep 40;
 private _powerupspawnpunkte = ["powerup_1", "powerup_2", "powerup_3", "powerup_4", "powerup_5", "powerup_6", "powerup_7", "powerup_8", "powerup_9", "powerup_10", "powerup_11", "powerup_12", "powerup_13", "powerup_14", "powerup_15", "powerup_16", "powerup_17", "powerup_18", "powerup_19", "powerup_20"];
 private _object1 = poweruporb;
 private _object2 = powerupzone;
-private _marker = selectRandom _powerupspawnpunkte;
 private _height = 30;
 
-private _markerPos = getMarkerPos _marker;
-private _newPos = [_markerPos select 0, _markerPos select 1, _height];
+if (isServer) then {
+    [_object2, [_object1, [0, 0, 0]]] remoteExec ["attachTo", 0, true];
 
-_object1 setPosATL _newPos;
-_object2 setPosATL _newPos;
+    for "_i" from 1 to 30 do {
+        sleep 40;
+        private _marker = selectRandom _powerupspawnpunkte;
+
+        private _markerPos = getMarkerPos _marker;
+        private _newPos = [_markerPos select 0, _markerPos select 1, _height];
+
+        [_object1, _newPos] remoteExec ["setPosATL", 0, true];
+    };
 };

--- a/scripts/powerupparker.sqf
+++ b/scripts/powerupparker.sqf
@@ -3,8 +3,11 @@ private _object2 = powerupzone;
 private _marker = "powerupparkplatz";
 private _height = 0;
 
-private _markerPos = getMarkerPos _marker;
-private _newPos = [_markerPos select 0, _markerPos select 1, _height];
+if (isServer) then {
+    [_object2, [_object1, [0, 0, 0]]] remoteExec ["attachTo", 0, true];
 
-_object1 setPosATL _newPos;
-_object2 setPosATL _newPos;
+    private _markerPos = getMarkerPos _marker;
+    private _newPos = [_markerPos select 0, _markerPos select 1, _height];
+
+    [_object1, _newPos] remoteExec ["setPosATL", 0, true];
+};


### PR DESCRIPTION
## Summary
- Attach trigger zone to power-up orb so it follows automaticly
- Move only orb across spawn markers via remoteExec

## Testing
- `sqflint scripts/powerup.sqf` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `pip install sqflint` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68948c9e3318832fad35e87a436379fe